### PR TITLE
supported using GET params for validation

### DIFF
--- a/src/ngRemoteValidate.js
+++ b/src/ngRemoteValidate.js
@@ -82,13 +82,23 @@
                         request = $timeout( function( ) {
                             el.addClass( 'ng-processing' );
                             ngModel.$processing = true;
-                            var calls = [],
+							var calls = [],
                                 i = 0,
-                                l = options.urls.length;
-                            for( ; i < l; i++ ) {
-                                calls.push( $http( { method: options.ngRemoteMethod, url: options.urls[ i ], data: { value: value } } ) );
+                                l = options.urls.length,
+                                toValidate = { value: value },
+                                httpOpts = { method: options.ngRemoteMethod };
+
+                            if(options.ngRemoteMethod == 'POST'){
+                                httpOpts.data = toValidate;
+                            } else {
+                                httpOpts.params = toValidate;
                             }
 
+                            for( ; i < l; i++ ) {
+
+                                httpOpts.url =  options.urls[ i ];
+                                calls.push( $http( httpOpts ) );
+                            }
                             $q.all( calls ).then( setValidation );
                             
                         }, options.ngRemoteThrottle );


### PR DESCRIPTION
For GET requests, `$http` doesn't use the `data` object. To pass data to the validation endpoint via GET we need to use the `params` object. Since this also applies to the POST method, we need to check the method and set the proper object so POSTs don't get a query string they don't need. 
