### PR TITLE
Adds onto the 'array of urls' concept, by allowing 'objects of urls'

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -6,7 +6,7 @@ ngRemoveValidate makes it easy for you to validate form fields agents data from 
 
 - Drop in solution for Ajax validation of any text or password input
 
-- Works with Angulars built in validation and cab be accessed at `formName.inputName.$error.ngRemoteValidate`
+- Works with Angulars built in validation and can be accessed at `formName.inputName.$error.ngRemoteValidate`
 
 - Throttles server requests (default 400ms) and can be set with `ng-remote-throttle="550"`
 
@@ -86,7 +86,7 @@ This will be a basic change password form that requires the user to enter their 
 ##Options##
 There are a few defaults that can be overwritten with options. They are:
 
-- `ng-remote-validate` takes a string or an Array of string i.e. `ng-remote-validate="/url/one"` or `ng-remote-validate="[ '/url/one', '/url/two' ]"`
+- `ng-remote-validate` takes a string, an Array of string i.e. `ng-remote-validate="/url/one"` or `ng-remote-validate="[ '/url/one', '/url/two' ]"`, or an Object of string/validation pairs i.e. `ng-remote-validate="{ '/url/validate/unique' : 'unique', '/url/validate/blacklist' : 'blacklisted'}"`, which would respectively set `formName.inputName.$error.unique` and `formName.inputName.$error.blacklisted` in addition to the catch-all `formName.inputName.$error.ngRemoteValidate`.
 - `ng-remote-throttle` (default: 400) Users inactivity length before sending validation requests to the server
 - `ng-remote-method` (default: 'POST') Type of request you would like to send
 

--- a/src/ngRemoteValidate.js
+++ b/src/ngRemoteValidate.js
@@ -27,6 +27,9 @@
 
                     if( options.ngRemoteValidate.charAt( 0 ) === '[' ) {
                         options.urls = eval( options.ngRemoteValidate );
+                    } else if (options.ngRemoteValidate.charAt( 0 ) === '{') {
+                        options.keys = eval( '(' + options.ngRemoteValidate + ')' );
+                        options.urls = Object.keys( options.keys );
                     } else {
                         options.urls = [ options.ngRemoteValidate ];
                     }
@@ -40,7 +43,11 @@
                     shouldProcess = function( value ) {
                         var otherRulesInValid = false;
                         for ( var p in ngModel.$error ) {
-                            if ( ngModel.$error[ p ] && p != directiveId ) {
+                            var checkedKey = !options.hasOwnProperty('keys') ||
+                                !(Object.keys(options.keys).filter(function(k) {
+                                    return options.keys[k] === p;
+                                })[0]);
+                            if ( ngModel.$error[ p ] && p != directiveId && checkedKey ) {
                                 otherRulesInValid = true;
                                 break;
                             }
@@ -51,11 +58,22 @@
                     setValidation = function( response, skipCache ) {
                         var i = 0,
                             l = response.length,
+                            useKeys = options.hasOwnProperty('keys'),
                             isValid = true;
                         for( ; i < l; i++ ) {
                             if( !response[ i ].data.isValid ) {
                                 isValid = false;
-                                break;
+                                if (!useKeys) {
+                                    break;
+                                }
+                            }
+                            var canSetKey = (useKeys &&
+                                response[ i ].hasOwnProperty('config') &&
+                                options.keys[ response[ i ].config.url ]);
+
+                            if (canSetKey) {
+                                var key = options.keys[ response[ i ].config.url ];
+                                ngModel.$setValidity( key, response[ i ].data.isValid );
                             }
                         }
                         if( !skipCache ) {


### PR DESCRIPTION
Docs updated
Fixes a typo in docs (cab -> can)

E.g. `ng-remote-validate="{ '/url/validate/unique' : 'unique', '/url/validate/blacklist' : 'blacklisted'}"` would curate `formName.inputName.$error.unique` and `formName.inputName.$error.blacklisted` in addition to `formName.inputName.$error.ngRemoteValidate`.
