### PR TITLE
Add formatted value property

### DIFF
--- a/src/ngRemoteValidate.js
+++ b/src/ngRemoteValidate.js
@@ -85,6 +85,11 @@
                                 var key = options.keys[ response[ i ].config.url ];
                                 ngModel.$setValidity( key, response[ i ].data.isValid );
                             }
+							
+							if( response[ i ].data.formattedValue ) {
+								ngModel.$setViewValue(response[ i ].data.formattedValue);
+								ngmodel.$render();
+							}
                         }
                         if( !skipCache ) {
                             addToCache( response );    

--- a/src/ngRemoteValidate.js
+++ b/src/ngRemoteValidate.js
@@ -27,7 +27,7 @@
                         };
 
                     angular.extend( options, attrs );
-					//TODO: Use Cain of Responsibility to reduce complexity.
+                    //TODO: Use Cain of Responsibility to reduce complexity.
                     if( options.ngRemoteValidate.charAt( 0 ) === '[' ) {
                         options.urls = eval( options.ngRemoteValidate );
                     } else if (options.ngRemoteValidate.charAt( 0 ) === '{') {
@@ -48,7 +48,7 @@
                         for ( var p in ngModel.$error ) {
                             var checkedKey = !options.hasOwnProperty( 'keys' ) ||
                                              !( Object.keys(options.keys )
-								.filter( function( k ) {
+                                .filter( function( k ) {
                                     return options.keys[ k ] === p;
                                 } )[ 0 ] );
                             if ( ngModel.$error[ p ] && p != directiveId && checkedKey ) {
@@ -76,7 +76,7 @@
                                     break;
                                 }
                             }
-							
+
                             var canSetKey = ( useKeys &&
                                               response[ i ].hasOwnProperty( 'config' ) &&
                                               options.keys[ response[ i ].config.url ] );
@@ -85,14 +85,14 @@
                                 var key = options.keys[ response[ i ].config.url ];
                                 ngModel.$setValidity( key, response[ i ].data.isValid );
                             }
-							
-							if( response[ i ].data.formattedValue ) {
-								ngModel.$setViewValue(response[ i ].data.formattedValue);
-								ngModel.$render();
-							}
+
+                            if( response[ i ].data.formattedValue ) {
+                                ngModel.$setViewValue( response[ i ].data.formattedValue );
+                                ngModel.$render( );
+                            }
                         }
                         if( !skipCache ) {
-                            addToCache( response );    
+                            addToCache( response );
                         }
                         ngModel.$setValidity( directiveId, isValid );
                         ngModel.$processing = ngModel.$pending = ngForm.$pending = false;
@@ -111,24 +111,24 @@
                         if ( cache[ value ] ) {
                             return setValidation( cache[ value ], true );
                         }
-                        
-                        //Set processing now, before the delay. 
+
+                        //Set processing now, before the delay.
                         //Check first to reduce DOM updates
                         if( !ngModel.$pending ) {
                             ngModel.$processing = ngModel.$pending = ngForm.$pending = true;
                         }
-                        
+
                         if ( request ) {
                             $timeout.cancel( request );
                         }
 
                         request = $timeout( function( ) {
-							var calls = [],
+                            var calls = [],
                                 i = 0,
                                 l = options.urls.length,
                                 toValidate = { value: value },
                                 httpOpts = { method: options.ngRemoteMethod };
-                            
+
                             if ( scope[ el[0].name + 'SetArgs' ] ) {
                                 toValidate = scope[el[0].name + 'SetArgs'](value, el, attrs, ngModel);
                             }
@@ -150,7 +150,7 @@
                             }
 
                             $q.all( calls ).then( setValidation );
-                            
+
                         }, options.ngRemoteThrottle );
                         return true;
                     };
@@ -166,5 +166,5 @@
     angular.module( 'remoteValidation', [] )
            .constant('MODULE_VERSION', '##_version_##')
            .directive( directiveId, [ '$http', '$timeout', '$q', remoteValidate ] );
-           
+
 })( this.angular );

--- a/src/ngRemoteValidate.js
+++ b/src/ngRemoteValidate.js
@@ -88,7 +88,7 @@
 							
 							if( response[ i ].data.formattedValue ) {
 								ngModel.$setViewValue(response[ i ].data.formattedValue);
-								ngmodel.$render();
+								ngModel.$render();
 							}
                         }
                         if( !skipCache ) {


### PR DESCRIPTION
Sometimes we want to pass a formatted version of the valid input to the UI. One example is to change a valid date from 01/02/2003 (which might be difficult to read internationally) to a more explicit 01 February 2003.

I have added an optional property to the response object (only when isValid is true). When .formattedValue is provided, the view is updated to reflect the value assigned to it.