### PR TITLE
Reset state of each validation when field is empted

### DIFF
--- a/src/ngRemoteValidate.js
+++ b/src/ngRemoteValidate.js
@@ -105,6 +105,14 @@
                              }
                             ngModel.$setPristine();
                             ngModel.$setValidity( directiveId, true);
+                            if ( options.hasOwnProperty( 'keys' ) ) {
+                                var i = 0,
+                                    l = options.urls.length;
+                                for( ; i < l; i++ ) {
+                                    var key = options.keys[ options.urls[i] ];
+                                    ngModel.$setValidity( key, true);
+                                }
+                            }
                             return;
                         }
 


### PR DESCRIPTION
In additition to PR https://github.com/webadvanced/ng-remote-validate/pull/17 for key-validation pairs like `ng-remote-validate="{ '/url/validate/unique' : 'unique', '/url/validate/blacklist' : 'blacklisted'}"`
