### PR TITLE
Pass 'window.angular' instead of 'this.angular'

### DIFF
--- a/src/ngRemoteValidate.js
+++ b/src/ngRemoteValidate.js
@@ -171,4 +171,4 @@
            .constant('MODULE_VERSION', '##_version_##')
            .directive( directiveId, [ '$http', '$timeout', '$q', remoteValidate ] );
 
-})( this.angular );
+})( window.angular );


### PR DESCRIPTION
The reason for this is to allow using this module with `webpack` module bundler.
Webpack places module inside a function that's why `this` no longer pointing to Global Object and angular becomes `undefined`.
